### PR TITLE
feat(modules): add IntelligentMode

### DIFF
--- a/BPSR-ZDPS/DataTypes/Modules/SolverConfig.cs
+++ b/BPSR-ZDPS/DataTypes/Modules/SolverConfig.cs
@@ -12,11 +12,13 @@ namespace BPSR_ZDPS.DataTypes.Modules
         public byte[] LinkLevelBonus = DefaultLinkLevels;
         public bool ValueAllStats = true;
         public int NumModules = 5;
+        public bool IntelligentMode = false;
 
         public string SaveToString(bool asBase64 = false)
         {
             var sb = new StringBuilder();
             sb.Append("ZMO:");
+            sb.Append(IntelligentMode ? "1;" : "0;");
             for (int i = 0; i < StatPriorities.Count; i++)
             {
                 var stat = $"{StatPriorities[i].Id}-{(byte)StatPriorities[i].StatMode}-{StatPriorities[i].ReqLevel}";
@@ -50,15 +52,28 @@ namespace BPSR_ZDPS.DataTypes.Modules
                     var configParts = str.Substring(4).Split('|');
                     if (configParts.Length > 1)
                     {
-                        var statPriorites = configParts[0].Split(",");
+                        var statsPart = configParts[0];
+                        if (statsPart.Contains(";"))
+                        {
+                            var semiParts = statsPart.Split(';');
+                            IntelligentMode = semiParts[0] == "1";
+                            statsPart = semiParts[1];
+                        }
+                        else
+                        {
+                            IntelligentMode = false;
+                        }
+
+                        var statPriorites = statsPart.Split(",");
                         foreach (var stat in statPriorites)
                         {
+                            if (string.IsNullOrWhiteSpace(stat)) continue;
                             var statParts = stat.Split("-");
                             var prio = new StatPrio()
                             {
                                 Id = int.Parse(statParts[0]),
                                 MinLevel = 0, //Math.Clamp(int.Parse(statParts[1]), 0, 20),
-                                StatMode = (StatMode)Math.Clamp(int.Parse(statParts[1]), 0, 1),
+                                StatMode = (StatMode)Math.Clamp(int.Parse(statParts[1]), 0, 2),
                                 ReqLevel = Math.Clamp(int.Parse(statParts[2]), 0, 20),
                             };
 

--- a/BPSR-ZDPS/Managers/ModuleOptimizer.V2.cs
+++ b/BPSR-ZDPS/Managers/ModuleOptimizer.V2.cs
@@ -20,7 +20,6 @@ namespace BPSR_ZDPS.Managers
 
             var numCombos = CountCombinations(modStatVecs.Length, config.NumModules);
             Log.Information("Searching {NumCombos:N0} combos...", numCombos);
-            int numModuleCombosProcessed = 0;
 
             var items = new List<Module>();
             for (int itemIdx = 0; itemIdx < modStatVecs.Length; itemIdx++)
@@ -54,8 +53,6 @@ namespace BPSR_ZDPS.Managers
             optimizer.LinkLevelBonus = config.LinkLevelBonus;
             optimizer.NumModules = config.NumModules;
             var bests = optimizer.FindBestSet(items, statPrios, cancelToken);
-
-            Log.Information("Num Module Combos Processed: {NumCombos:N0}", numModuleCombosProcessed);
 
             var results = new List<ModComboResult>();
             foreach (var best in bests)
@@ -162,9 +159,17 @@ namespace BPSR_ZDPS.Managers
                 {
                     var newStatPrio = new StatPrio();
                     newStatPrio.Id = possibleStats[statPrio.Id];
-                    newStatPrio.ReqLevel = statPrio.ReqLevel;
+                    if (config.IntelligentMode)
+                    {
+                        newStatPrio.StatMode = StatMode.Intelligent;
+                        newStatPrio.ReqLevel = 0;
+                    }
+                    else
+                    {
+                        newStatPrio.StatMode = statPrio.StatMode;
+                        newStatPrio.ReqLevel = statPrio.ReqLevel;
+                    }
                     newStatPrio.MinLevel = statPrio.MinLevel;
-                    newStatPrio.StatMode = statPrio.StatMode;
                     statPrios.Add(newStatPrio);
                 }
             }
@@ -324,7 +329,7 @@ namespace BPSR_ZDPS.Managers
             public List<ModuleSetResult> FindBestSet(List<Module> items, List<StatPrio> priorities, CancellationToken cancelToken)
             {
                 TopResults = new();
-                BestScore = new int[priorities.Count];
+                BestScore = new int[priorities.Count + 2];
 
                 items = items.OrderBy(i => EstimateItemScore(i, priorities), ScoreComparer).ToList();
                 Search(items, priorities, 0, new List<Module>(), new int[MAX_NUM_STATS], cancelToken);
@@ -351,101 +356,134 @@ namespace BPSR_ZDPS.Managers
                     return;
                 }
 
-                /*
-                for (int i = start; i < items.Count; i++)
+                // Update real-time progress percentage on the top level (first chosen module)
+                if (currentSet.Count == 0)
                 {
-                    var item = items[i];
-
-                    foreach (var stat in item.Stats)
-                    {
-                        totals[stat.Key] += stat.Value;
-                    }
-
-                    currentSet.Add(item);
-
-                    // Branch-and-bound prune
-                    if (CanStillBeatBest(items, priorities, i + 1, currentSet.Count, totals))
-                    {
-                        Search(items, priorities, i + 1, currentSet, totals, cancelToken);
-                    }
-
-                    currentSet.RemoveAt(currentSet.Count - 1);
-
-                    foreach (var stat in item.Stats)
-                    {
-                        totals[stat.Key] -= stat.Value;
-                    }
-                }*/
-
-                var candidates = new List<(int Index, int[] Score)>();
-
-                for (int i = start; i < items.Count; i++)
-                {
-                    Module item = items[i];
-
-                    var projected = new int[MAX_NUM_STATS];
-                    Array.Copy(totals, projected, MAX_NUM_STATS);
-
-                    foreach (var stat in item.Stats)
-                    {
-                        projected[stat.Key] += stat.Value;
-                    }
-
-                    var projectedScore = ScoreTotals(projected, priorities);
-
-                    candidates.Add((i, projectedScore));
+                    int pct = (int)((double)start / items.Count * 100.0);
+                    BPSR_ZDPS.ModuleSolver.ProgressStatus = $"({pct})";
                 }
 
-                var topCandidates = candidates.OrderBy(x => x.Score, ScoreComparer).Take(MaxCanadates);
-
-                foreach (var candidate in topCandidates)
+                // To eliminate massive recursive overhead, only dynamically order candidates at the very top level (where currentSet.Count == 0).
+                // For deeper levels, directly perform fast and clean Branch and Bound DFS.
+                if (currentSet.Count == 0)
                 {
-                    var i = candidate.Index;
+                    var candidates = new List<(int Index, int[] Score)>();
 
-                    Module item = items[i];
-
-                    foreach (var stat in item.Stats)
+                    for (int i = start; i < items.Count; i++)
                     {
-                        totals[stat.Key] += stat.Value;
+                        Module item = items[i];
+
+                        var projected = new int[MAX_NUM_STATS];
+                        Array.Copy(totals, projected, MAX_NUM_STATS);
+
+                        foreach (var stat in item.Stats)
+                        {
+                            projected[stat.Key] += stat.Value;
+                        }
+
+                        var projectedScore = ScoreTotals(projected, priorities, true);
+
+                        candidates.Add((i, projectedScore));
                     }
 
-                    currentSet.Add(item);
+                    var topCandidates = candidates.OrderBy(x => x.Score, ScoreComparer).Take(MaxCanadates);
 
-                    if (CanStillBeatBest(items, priorities, i + 1, currentSet.Count, totals))
+                    foreach (var candidate in topCandidates)
                     {
-                        Search(items, priorities, i + 1, currentSet, totals, cancelToken);
+                        var i = candidate.Index;
+
+                        Module item = items[i];
+
+                        foreach (var stat in item.Stats)
+                        {
+                            totals[stat.Key] += stat.Value;
+                        }
+
+                        currentSet.Add(item);
+
+                        if (CanStillBeatBest(items, priorities, i + 1, currentSet.Count, totals))
+                        {
+                            Search(items, priorities, i + 1, currentSet, totals, cancelToken);
+                        }
+
+                        currentSet.RemoveAt(currentSet.Count - 1);
+
+                        foreach (var stat in item.Stats)
+                        {
+                            totals[stat.Key] -= stat.Value;
+                        }
                     }
-
-                    currentSet.RemoveAt(currentSet.Count - 1);
-
-                    foreach (var stat in item.Stats)
+                }
+                else
+                {
+                    // Clean and ultra-fast direct Branch and Bound DFS
+                    for (int i = start; i < items.Count; i++)
                     {
-                        totals[stat.Key] -= stat.Value;
+                        var item = items[i];
+
+                        foreach (var stat in item.Stats)
+                        {
+                            totals[stat.Key] += stat.Value;
+                        }
+
+                        currentSet.Add(item);
+
+                        if (CanStillBeatBest(items, priorities, i + 1, currentSet.Count, totals))
+                        {
+                            Search(items, priorities, i + 1, currentSet, totals, cancelToken);
+                        }
+
+                        currentSet.RemoveAt(currentSet.Count - 1);
+
+                        foreach (var stat in item.Stats)
+                        {
+                            totals[stat.Key] -= stat.Value;
+                        }
                     }
                 }
             }
 
             int[] ScoreTotals(int[] totals, List<StatPrio> priorities, bool noPenalty = false)
             {
-                var scores = new int[priorities.Count];
+                var scores = new int[priorities.Count + 2];
+                var isPriority = new bool[MAX_NUM_STATS];
+                bool hasIntelligentMode = false;
 
                 for (int i = 0; i < priorities.Count; i++)
                 {
-                    var p = priorities[i];
+                    isPriority[priorities[i].Id] = true;
+                }
 
-                    int target = Math.Max(1, p.ReqLevel);
+                int priorityScore = 0;
+                int presenceBonus = 0;
+                for (int i = 0; i < priorities.Count; i++)
+                {
+                    var p = priorities[i];
                     int val = Math.Min(totals[p.Id], MAX_STAT_VALUE);
 
                     if (!noPenalty && (val < p.ReqLevel || (p.StatMode == StatMode.Exactly && p.ReqLevel != val )))
                     {
-                        var minValue = new int[priorities.Count];
-                        for (int x = 0; x < minValue.Length; x++)
-                        {
-                            minValue[x] = int.MinValue;
-                        }
+                        return new int[priorities.Count + 2];
+                    }
 
-                        return new int[priorities.Count];
-                        //scores[i] = int.MinValue;
+                    if (p.StatMode == StatMode.Intelligent)
+                    {
+                        hasIntelligentMode = true;
+                        var intelligentBonus = val switch
+                        {
+                            >= 20 => 5000,
+                            >= 16 => 2000,
+                            >= 12 => 500,
+                            >= 8 => 100,
+                            >= 4 => 50,
+                            >= 1 => 10,
+                            _ => 0
+                        };
+                        if (val >= 1)
+                        {
+                            presenceBonus += 100;
+                        }
+                        priorityScore += intelligentBonus;
                     }
                     else
                     {
@@ -461,10 +499,63 @@ namespace BPSR_ZDPS.Managers
                         };
 
                         var breakPointBonus = (byte)LinkLevelBonus[bonusIdx];
-
-                        scores[i] = val + breakPointBonus;
+                        priorityScore += val + breakPointBonus;
                     }
                 }
+
+                int thresholdScore = 0;
+                int totalSum = 0;
+                for (int statId = 0; statId < MAX_NUM_STATS; statId++)
+                {
+                    int statValue = Math.Min(totals[statId], MAX_STAT_VALUE);
+                    totalSum += statValue;
+                    thresholdScore += statValue switch
+                    {
+                        >= 20 => 1000 + (statValue - 20) * 20,
+                        >= 16 => 500 + (statValue - 16) * 15,
+                        >= 12 => 100 + (statValue - 12) * 5,
+                        _ => 0
+                    };
+                }
+
+                if (hasIntelligentMode)
+                {
+                    int nonPriorityTotal = 0;
+                    for (int statId = 0; statId < MAX_NUM_STATS; statId++)
+                    {
+                        if (!isPriority[statId])
+                        {
+                            nonPriorityTotal += totals[statId];
+                        }
+                    }
+
+                    int totalScore = priorityScore + presenceBonus + thresholdScore - (nonPriorityTotal * 5);
+                    scores[0] = totalScore;
+                    scores[1] = thresholdScore;
+                    scores[2] = -(nonPriorityTotal * 5);
+                    return scores;
+                }
+
+                for (int i = 0; i < priorities.Count; i++)
+                {
+                    var p = priorities[i];
+                    int val = Math.Min(totals[p.Id], MAX_STAT_VALUE);
+                    var bonusIdx = val switch
+                    {
+                        >= 20 => 5,
+                        >= 16 => 4,
+                        >= 12 => 3,
+                        >= 8 => 2,
+                        >= 4 => 1,
+                        >= 1 => 0,
+                        _ => 0
+                    };
+                    var breakPointBonus = (byte)LinkLevelBonus[bonusIdx];
+                    scores[i] = val + breakPointBonus;
+                }
+
+                scores[priorities.Count] = thresholdScore + totalSum;
+                scores[priorities.Count + 1] = 0;
 
                 return scores;
             }
@@ -506,7 +597,7 @@ namespace BPSR_ZDPS.Managers
 
                     var breakPointBonus = (byte)LinkLevelBonus[bonusIdx];
 
-                    optimistic[p.Id] = added + breakPointBonus;
+                    optimistic[p.Id] += added + breakPointBonus;
                 }
 
                 int[] upperBound = ScoreTotals(optimistic, priorities, true);
@@ -516,22 +607,70 @@ namespace BPSR_ZDPS.Managers
 
             int[] EstimateItemScore(Module item, List<StatPrio> priorities)
             {
-                var scores = new int[priorities.Count];
+                var scores = new int[priorities.Count + 2];
+
+                int totalSum = 0;
+                int presenceBonus = 0;
+                bool hasIntelligentMode = priorities.Any(p => p.StatMode == StatMode.Intelligent);
+                int priorityScore = 0;
 
                 for (int i = 0; i < priorities.Count; i++)
                 {
                     var p = priorities[i];
+                    int val = 0;
 
-                    if (item.Stats.TryGetValue(p.Id, out int val))
+                    if (item.Stats.TryGetValue(p.Id, out int itemVal))
                     {
-                        scores[i] = Math.Min(val, MAX_STAT_VALUE);
+                        val = Math.Min(itemVal, MAX_STAT_VALUE);
+                    }
+
+                    if (p.StatMode == StatMode.Intelligent)
+                    {
+                        var intelligentBonus = val switch
+                        {
+                            >= 20 => 5000,
+                            >= 16 => 2000,
+                            >= 12 => 500,
+                            >= 8 => 100,
+                            >= 4 => 50,
+                            >= 1 => 10,
+                            _ => 0
+                        };
+                        if (val >= 1)
+                        {
+                            presenceBonus += 100;
+                        }
+                        priorityScore += intelligentBonus;
                     }
                     else
                     {
-                        scores[i] = 0;
+                        priorityScore += val;
                     }
+
+                    totalSum += val;
                 }
 
+                if (hasIntelligentMode)
+                {
+                    scores[0] = priorityScore + presenceBonus + totalSum;
+                    scores[1] = totalSum;
+                    scores[2] = 0;
+                    return scores;
+                }
+
+                for (int i = 0; i < priorities.Count; i++)
+                {
+                    var p = priorities[i];
+                    int val = 0;
+                    if (item.Stats.TryGetValue(p.Id, out int itemVal))
+                    {
+                        val = Math.Min(itemVal, MAX_STAT_VALUE);
+                    }
+                    scores[i] = val;
+                }
+
+                scores[priorities.Count] = totalSum;
+                scores[priorities.Count + 1] = 0;
                 return scores;
             }
 

--- a/BPSR-ZDPS/Managers/ModuleOptimizer.cs
+++ b/BPSR-ZDPS/Managers/ModuleOptimizer.cs
@@ -1,6 +1,7 @@
 ﻿using BPSR_ZDPS.DataTypes.Modules;
 using Serilog;
 using System.Diagnostics;
+using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using ZLinq;
@@ -9,6 +10,8 @@ namespace BPSR_ZDPS.Managers
 {
     public partial class ModuleOptimizer
     {
+        private const int PrefilterTopNPerAttribute = 60;
+        private const int PrefilterTopNTotalValue = 100;
         public SolverResult Solve(SolverConfig config, PlayerModDataSave playerMods, SolverModes mode, CancellationToken cancelToken)
         {
             var sw = Stopwatch.StartNew();
@@ -690,24 +693,109 @@ namespace BPSR_ZDPS.Managers
 
         private List<long> FilterModulesWithStats(SolverConfig config, PlayerModDataSave playerMods)
         {
-            var modules = new List<long>();
-            foreach (var item in playerMods.ModulesPackage.Items)
+            if (playerMods?.ModulesPackage?.Items == null || playerMods.Mod == null)
             {
-                var qualityValue = Math.Clamp(item.Value.Quality, 0, 4);
-                if (config.QualitiesV2.TryGetValue(qualityValue, out var quality) ? quality : false)
+                return new List<long>();
+            }
+
+            if (!config.IntelligentMode)
+            {
+                var modules = new List<long>();
+                foreach (var item in playerMods.ModulesPackage.Items)
                 {
-                    if (item.Value.ModNewAttr.ModParts.Any(x => config.StatPriorities.Any(y => y.Id == x)))
+                    var qualityValue = Math.Clamp(item.Value.Quality, 0, 4);
+                    if (config.QualitiesV2.TryGetValue(qualityValue, out var quality) ? quality : false)
                     {
-                        modules.Add(item.Key);
+                        if (item.Value.ModNewAttr.ModParts.Any(x => config.StatPriorities.Any(y => y.Id == x)))
+                        {
+                            modules.Add(item.Key);
+                        }
                     }
+                }
+                return modules.ToList();
+            }
+
+            var candidateModules = new HashSet<long>();
+            var modulesByQuality = playerMods.ModulesPackage.Items
+                .Where(item => config.QualitiesV2.TryGetValue(Math.Clamp(item.Value.Quality, 0, 4), out var quality) ? quality : false)
+                .ToList();
+
+            if (!config.StatPriorities.Any())
+            {
+                candidateModules.UnionWith(modulesByQuality.Select(item => item.Key));
+                return candidateModules.ToList();
+            }
+
+            // High-Synergy Filter: If at least 2 priority stats are chosen, require candidates to have at least 2 prioritized stats if possible
+            var prioIds = config.StatPriorities.Select(x => x.Id).ToHashSet();
+            if (prioIds.Count >= 2)
+            {
+                var highSynergyModules = modulesByQuality.Where(item => 
+                    item.Value.ModNewAttr.ModParts.Count(partId => prioIds.Contains(partId)) >= 2
+                ).ToList();
+
+                // Only restrict the pool if there are enough high-synergy modules to form a valid combination
+                if (highSynergyModules.Count >= config.NumModules)
+                {
+                    Log.Information("Applying high-synergy filter: restricted candidate pool from {OriginalCount} to {SynergyCount} modules with >= 2 prioritized stats.", modulesByQuality.Count, highSynergyModules.Count);
+                    modulesByQuality = highSynergyModules;
                 }
             }
 
-            return modules.ToList();
+            int GetModuleTotalValue(KeyValuePair<long, Zproto.Item> item)
+            {
+                var modInfo = playerMods.Mod.ModInfos[item.Key];
+                var total = 0;
+                for (int i = 0; i < item.Value.ModNewAttr.ModParts.Count; i++)
+                {
+                    total += modInfo.InitLinkNums[i];
+                }
+                return total;
+            }
+
+            int GetPriorityStatValue(KeyValuePair<long, Zproto.Item> item, int statId)
+            {
+                var modInfo = playerMods.Mod.ModInfos[item.Key];
+                var total = 0;
+                for (int i = 0; i < item.Value.ModNewAttr.ModParts.Count; i++)
+                {
+                    if (item.Value.ModNewAttr.ModParts[i] == statId)
+                    {
+                        total += modInfo.InitLinkNums[i];
+                    }
+                }
+                return total;
+            }
+
+            candidateModules.UnionWith(modulesByQuality
+                .OrderByDescending(GetModuleTotalValue)
+                .Take(PrefilterTopNTotalValue)
+                .Select(item => item.Key));
+
+            foreach (var statPrio in config.StatPriorities)
+            {
+                candidateModules.UnionWith(modulesByQuality
+                    .Select(item => new { item.Key, Value = GetPriorityStatValue(item, statPrio.Id) })
+                    .Where(x => x.Value > 0)
+                    .OrderByDescending(x => x.Value)
+                    .Take(PrefilterTopNPerAttribute)
+                    .Select(x => x.Key));
+            }
+
+            var moduleTotalValues = modulesByQuality.ToDictionary(item => item.Key, item => GetModuleTotalValue(item));
+            return candidateModules
+                .OrderByDescending(id => moduleTotalValues.TryGetValue(id, out var total) ? total : 0)
+                .ThenBy(id => id)
+                .ToList();
         }
 
         private ushort GetStatMultiplier(SolverConfig config, int statId)
         {
+            if (!config.StatPriorities.Any())
+            {
+                return (ushort)(config.ValueAllStats ? 1 : 0);
+            }
+
             for (int i = 0; i < config.StatPriorities.Count; i++)
             {
                 if (config.StatPriorities[i].Id == statId)
@@ -766,10 +854,10 @@ namespace BPSR_ZDPS.Managers
 
         public int CalcCombosCombatScore(PlayerModDataSave playerMods, ModuleSet modSet)
         {
-            Dictionary<int, PowerCore> coresDict = [];
+            Dictionary<int, PowerCore> coresDict = new Dictionary<int, PowerCore>();
             foreach (var mod in modSet.Mods)
             {
-                if (mod != 0)
+                if (mod != -1)
                 {
                     var modCores = GetModPowerCores(playerMods, mod);
                     foreach (var modCore in modCores)
@@ -792,7 +880,7 @@ namespace BPSR_ZDPS.Managers
             foreach (var core in coresDict.Values)
             {
                 var enhanceLevel = 0;
-                int[] enhanceLevels = [1, 4, 8, 12, 16, 20];
+                int[] enhanceLevels = new int[] { 1, 4, 8, 12, 16, 20 };
                 for (int i = 0; i < 6; i++)
                 {
                     if (core.Value >= enhanceLevels[i])

--- a/BPSR-ZDPS/Windows/ModuleSolver.cs
+++ b/BPSR-ZDPS/Windows/ModuleSolver.cs
@@ -5,6 +5,7 @@ using Hexa.NET.ImGui;
 using Newtonsoft.Json;
 using Serilog;
 using System.Collections.Frozen;
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.Intrinsics.X86;
 using ZLinq;
@@ -38,6 +39,7 @@ namespace BPSR_ZDPS
         private static Task ModuleCalcTask;
         private static DateTime ModuleCalcStartTime = DateTime.Now;
         private static string CurrentPresetString = "";
+        public static string ProgressStatus = "";
         static int RunOnceDelayed = 0;
         private static bool ShouldTrackOpenState;
 
@@ -83,9 +85,22 @@ namespace BPSR_ZDPS
         {
             lock (PlayerModData)
             {
+                var modulePackage = data.ItemPackage?.Packages[5];
+                if (data.ItemPackage?.Packages != null)
+                {
+                    foreach (var kvp in data.ItemPackage.Packages)
+                    {
+                        if (kvp.Value?.Items != null && kvp.Value.Items.Any(item => item.Value?.ModNewAttr != null && item.Value.ModNewAttr.ModParts.Count > 0))
+                        {
+                            modulePackage = kvp.Value;
+                            break;
+                        }
+                    }
+                }
+
                 PlayerModData = new PlayerModDataSave()
                 {
-                    ModulesPackage = data.ItemPackage?.Packages[5] ?? null,
+                    ModulesPackage = modulePackage,
                     Mod = data?.Mod ?? null
                 };
 
@@ -143,7 +158,7 @@ namespace BPSR_ZDPS
                 if (ModuleCalcTask?.Status == TaskStatus.Running)
                 {
                     var timeTaken = DateTime.Now - ModuleCalcStartTime;
-                    DrawBanner($"Calculating best module combos!\nThis could take a while.\nElapsed: {timeTaken:mm\\:ss}", 0xFF005DD9, "Thinking.png", true,
+                    DrawBanner($"Calculating best module combos! {ProgressStatus}\nThis could take a while.\nElapsed: {timeTaken:mm\\:ss}", 0xFF005DD9, "Thinking.png", true,
                         (drawList, txtPos, txtSize, bannerHeight) =>
                         {
                             var cancelButtonStart = txtPos + new Vector2(0, 100);
@@ -403,6 +418,15 @@ namespace BPSR_ZDPS
             }
             ImGui.Spacing();
 
+            ImGui.AlignTextToFramePadding();
+            ImGui.TextUnformatted("Intelligent Mode"u8);
+            ImGui.SameLine();
+            if (ImGui.Checkbox("##IntelligentMode", ref SolverConfig.IntelligentMode))
+            {
+                configChanged = true;
+            }
+            ImGui.Spacing();
+
             ImGui.SeparatorText("Stat Priority");
             ImGui.Spacing();
 
@@ -629,24 +653,64 @@ namespace BPSR_ZDPS
             ImGui.SetItemTooltip("The minimum Link value needed for this stat to be considered.\nLeave 0 to use any Link.");
             */
 
+            var currentStatMode = SolverConfig.StatPriorities[i].StatMode;
+            if (currentStatMode == StatMode.Intelligent)
+            {
+                currentStatMode = StatMode.Atleast;
+                SolverConfig.StatPriorities[i].StatMode = StatMode.Atleast;
+                wasChanged = true;
+            }
+
+            ImGui.BeginDisabled(SolverConfig.IntelligentMode);
             if (ImGui.InputInt($"##ReqLevel{i}", ref SolverConfig.StatPriorities[i].ReqLevel, 0, ImGuiInputTextFlags.CharsDecimal))
             {
                 wasChanged = true;
             }
+            ImGui.EndDisabled();
             ImGui.SetItemTooltip("The required Link value needed for this stat to have for the combination to be considered.\nLeave 0 to use any Link.");
 
             ImGui.SetCursorPos(pos + new Vector2(availSize.X - 50, 5));
             ImGui.Dummy(new Vector2(-4, 0));
             ImGui.SameLine();
-            bool isAtleastMode = SolverConfig.StatPriorities[i].StatMode == StatMode.Atleast;
-            if (ImGui.Button($"{(isAtleastMode ? "A" : "E")}##StatMode{i}"))
+            
+            string statModeLabel;
+            if (SolverConfig.IntelligentMode)
             {
-                SolverConfig.StatPriorities[i].StatMode = isAtleastMode ? StatMode.Exactly : StatMode.Atleast;
+                statModeLabel = "I";
+            }
+            else
+            {
+                statModeLabel = currentStatMode switch
+                {
+                    StatMode.Atleast => "A",
+                    StatMode.Exactly => "E",
+                    _ => "A"
+                };
+            }
+
+            ImGui.BeginDisabled(SolverConfig.IntelligentMode);
+            if (ImGui.Button($"{statModeLabel}##StatMode{i}"))
+            {
+                if (currentStatMode == StatMode.Exactly)
+                {
+                    SolverConfig.StatPriorities[i].StatMode = StatMode.Atleast;
+                }
+                else
+                {
+                    SolverConfig.StatPriorities[i].StatMode = StatMode.Exactly;
+                }
                 wasChanged = true;
             }
-            ImGui.SetItemTooltip(isAtleastMode ?
-                "In this mode the combo must have ATLEAST this link value." :
-                "In this mode the combo must have EXACTLY this link value.");
+            ImGui.EndDisabled();
+
+            ImGui.SetItemTooltip(SolverConfig.IntelligentMode ? 
+                "Intelligent mode is globally enabled." : 
+                (currentStatMode switch
+                {
+                    StatMode.Atleast => "In this mode the combo must have ATLEAST this link value.",
+                    StatMode.Exactly => "In this mode the combo must have EXACTLY this link value.",
+                    _ => "Stat mode."
+                }));
 
             ImGui.SetCursorPos(pos + new Vector2(availSize.X - 25, 0));
             ImGui.PushFont(HelperMethods.Fonts["FASIcons"], 13.0f);
@@ -1240,6 +1304,7 @@ namespace BPSR_ZDPS
     public enum StatMode
     {
         Atleast,
-        Exactly
+        Exactly,
+        Intelligent
     }
 }


### PR DESCRIPTION
I updated the module selector with a 'smart filter.' The old version was too restrictive and a bit of a grind with all that manual work. I added a quick algorithm that tosses out the junk first and looks for at least 2 stats—this keeps the pool small so it’s not a huge process. Then, it finds the best combos from what's left. If you think there’s a better way to do it, let me know, this is just an idea.
https://github.com/mrsnakke/gachaIMG/blob/main/noww.png?raw=true